### PR TITLE
use parse() in the main fn instead of try_parse() to support --help c…

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,8 +16,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 		log::log_enabled!(log::Level::Debug)
 	);
 
-    let mut arguments = download::DownloadArguments::try_parse()
-        .expect("Wrong arguments received");
+    let mut arguments = download::DownloadArguments::parse();
     // let mut arguments = download::DownloadArguments {
     // 	repository: "sentence-transformers/all-MiniLM-L6-v2".to_string(),
     //  	repository_local_path: None,


### PR DESCRIPTION
use parse() in the main fn instead of try_parse() to support --help command